### PR TITLE
Fix: concurrency error 

### DIFF
--- a/Sources/GigMacrosPlugin/LogsMacro.swift
+++ b/Sources/GigMacrosPlugin/LogsMacro.swift
@@ -47,7 +47,7 @@ public struct LogManagerMacro: DeclarationMacro {
         class LogManager: @unchecked Sendable {
             static let logger = Logger(subsystem: \(subsystem.expression), category: \(category.expression))
             private static let staticQueue = DispatchQueue(label: "logManagerStaticQueue")
-                nonisolated(unsafe) private static var logLevelSynced: LogLevel = .none
+            nonisolated(unsafe) private static var logLevelSynced: LogLevel = .none
 
             static var logLevel: LogLevel {
                 get {

--- a/Sources/GigMacrosPlugin/LogsMacro.swift
+++ b/Sources/GigMacrosPlugin/LogsMacro.swift
@@ -45,11 +45,12 @@ public struct LogManagerMacro: DeclarationMacro {
         let logManager: DeclSyntax =
         """
         class LogManager: @unchecked Sendable {
+            static let shared = LogManager()
             static let logger = Logger(subsystem: \(subsystem.expression), category: \(category.expression))
-            private static let staticQueue = DispatchQueue(label: "logManagerStaticQueue")
-            nonisolated(unsafe) private static var logLevelSynced: LogLevel = .none
+            private let staticQueue = DispatchQueue(label: "logManagerStaticQueue")
+            private var logLevelSynced: LogLevel = .none
 
-            static var logLevel: LogLevel {
+            var logLevel: LogLevel {
                 get {
                     self.staticQueue.sync {
                         self.logLevelSynced
@@ -81,7 +82,7 @@ public struct LogDebugMacro: ExpressionMacro {
         let expression: ExprSyntax =
         """
         {
-        if LogManager.logLevel >= .debug {
+        if LogManager.shared.logLevel >= .debug {
             let message = \(argument)
             LogManager.logger.debug("\\(message)")
         }   
@@ -102,7 +103,7 @@ public struct LogInfoMacro: ExpressionMacro {
         let expression: ExprSyntax =
         """
         {
-        if LogManager.logLevel >= .info {
+        if LogManager.shared.logLevel >= .info {
             let message = \(argument)
             LogManager.logger.info("\\(message)")
         }
@@ -123,7 +124,7 @@ public struct LogWarnMacro: ExpressionMacro {
         let expression: ExprSyntax =
         """
         {
-        if LogManager.logLevel >= .error {
+        if LogManager.shared.logLevel >= .error {
             let message = \(argument)
             LogManager.logger.warning("\\(message)")
         }
@@ -144,7 +145,7 @@ public struct LogErrorMacro: ExpressionMacro {
         let expression: ExprSyntax =
         """
         {
-        if LogManager.logLevel >= .error {
+        if LogManager.shared.logLevel >= .error {
             guard let err = \(argument) as NSError? else { return }
             LogManager.logger.fault("\\(err.localizedDescription)\\n\\t⤷USER INFO: \\(err.userInfo)\\n")
         }

--- a/Sources/GigMacrosPlugin/LogsMacro.swift
+++ b/Sources/GigMacrosPlugin/LogsMacro.swift
@@ -47,7 +47,7 @@ public struct LogManagerMacro: DeclarationMacro {
         class LogManager: @unchecked Sendable {
             static let logger = Logger(subsystem: \(subsystem.expression), category: \(category.expression))
             private static let staticQueue = DispatchQueue(label: "logManagerStaticQueue")
-            private static var logLevelSynced: LogLevel = .none
+                nonisolated(unsafe) private static var logLevelSynced: LogLevel = .none
 
             static var logLevel: LogLevel {
                 get {

--- a/Tests/GigMacrosTests/GigMacrosTests.swift
+++ b/Tests/GigMacrosTests/GigMacrosTests.swift
@@ -43,7 +43,7 @@ final class GigMacrosTests: XCTestCase {
             class LogManager: @unchecked Sendable {
                 static let logger = Logger(subsystem: "SubsystemTest", category: "CategoryTest")
                 private static let staticQueue = DispatchQueue(label: "logManagerStaticQueue")
-                private static var logLevelSynced: LogLevel = .none
+                nonisolated(unsafe) private static var logLevelSynced: LogLevel = .none
 
                 static var logLevel: LogLevel {
                     get {

--- a/Tests/GigMacrosTests/GigMacrosTests.swift
+++ b/Tests/GigMacrosTests/GigMacrosTests.swift
@@ -43,7 +43,7 @@ final class GigMacrosTests: XCTestCase {
             class LogManager: @unchecked Sendable {
                 static let logger = Logger(subsystem: "SubsystemTest", category: "CategoryTest")
                 private static let staticQueue = DispatchQueue(label: "logManagerStaticQueue")
-                nonisolated(unsafe) private static var logLevelSynced: LogLevel = .none
+                private var logLevelSynced: LogLevel = .none
 
                 static var logLevel: LogLevel {
                     get {

--- a/Tests/GigMacrosTests/GigMacrosTests.swift
+++ b/Tests/GigMacrosTests/GigMacrosTests.swift
@@ -41,11 +41,12 @@ final class GigMacrosTests: XCTestCase {
                 }
             }
             class LogManager: @unchecked Sendable {
+                static let shared = LogManager()
                 static let logger = Logger(subsystem: "SubsystemTest", category: "CategoryTest")
-                private static let staticQueue = DispatchQueue(label: "logManagerStaticQueue")
+                private let staticQueue = DispatchQueue(label: "logManagerStaticQueue")
                 private var logLevelSynced: LogLevel = .none
 
-                static var logLevel: LogLevel {
+                var logLevel: LogLevel {
                     get {
                         self.staticQueue.sync {
                             self.logLevelSynced
@@ -75,7 +76,7 @@ final class GigMacrosTests: XCTestCase {
             expandedSource:
             #"""
             {
-                if LogManager.logLevel >= .debug {
+                if LogManager.shared.logLevel >= .debug {
                     let message = "Debug test"
                     LogManager.logger.debug("\(message)")
                 }
@@ -99,7 +100,7 @@ final class GigMacrosTests: XCTestCase {
             #"""
             let testString = "test"
             {
-                if LogManager.logLevel >= .debug {
+                if LogManager.shared.logLevel >= .debug {
                     let message = testString
                     LogManager.logger.debug("\(message)")
                 }
@@ -121,7 +122,7 @@ final class GigMacrosTests: XCTestCase {
             expandedSource:
             #"""
             {
-                if LogManager.logLevel >= .info {
+                if LogManager.shared.logLevel >= .info {
                     let message = "Info test"
                     LogManager.logger.info("\(message)")
                 }
@@ -145,7 +146,7 @@ final class GigMacrosTests: XCTestCase {
             #"""
             let testString = "test"
             {
-                if LogManager.logLevel >= .info {
+                if LogManager.shared.logLevel >= .info {
                     let message = testString
                     LogManager.logger.info("\(message)")
                 }
@@ -167,7 +168,7 @@ final class GigMacrosTests: XCTestCase {
             expandedSource:
             #"""
             {
-                if LogManager.logLevel >= .error {
+                if LogManager.shared.logLevel >= .error {
                     let message = "Warning test"
                     LogManager.logger.warning("\(message)")
                 }
@@ -191,7 +192,7 @@ final class GigMacrosTests: XCTestCase {
             #"""
             let testString = "test"
             {
-                if LogManager.logLevel >= .error {
+                if LogManager.shared.logLevel >= .error {
                     let message = testString
                     LogManager.logger.warning("\(message)")
                 }
@@ -213,7 +214,7 @@ final class GigMacrosTests: XCTestCase {
             expandedSource:
             #"""
             {
-                if LogManager.logLevel >= .error {
+                if LogManager.shared.logLevel >= .error {
                     guard let err = NSError() as NSError? else {
                         return
                     }
@@ -237,7 +238,7 @@ final class GigMacrosTests: XCTestCase {
             expandedSource:
             #"""
             {
-                if LogManager.logLevel >= .error {
+                if LogManager.shared.logLevel >= .error {
                     guard let err = nil as NSError? else {
                         return
                     }


### PR DESCRIPTION
Al revisar los warnings restantes, noté que aún persistía uno relacionado con concurrencia dentro de la macro. El problema se debía al uso de una propiedad static var, que en Swift 6 requiere agregar el modificador nonisolated(unsafe) para evitar errores de concurrencia. Sin embargo, al agregarlo, el compilador insertaba automáticamente un espacio (nonisolated (unsafe)), lo que provocaba un warning en Swift 5 y un error en Swift 6.

Para resolverlo, reemplacé la propiedad static con una instancia compartida (shared), lo que elimina la necesidad de nonisolated(unsafe) y mantiene la compatibilidad con ambas versiones del compilador. Con estos cambios, ya no se presentan advertencias relacionadas con concurrencia en las macros.